### PR TITLE
APIエラー処理のコードを変更

### DIFF
--- a/iOSEngineerCodeCheck/Controller/SearchViewController.swift
+++ b/iOSEngineerCodeCheck/Controller/SearchViewController.swift
@@ -31,23 +31,20 @@ final class SearchViewController: UIViewController{
     }
     
     private func getRepositoryData(searchWord: String){
-        do{
-            try GithubAPI.getRepositoryDataOf(searchWord){ [unowned self] (result) in
-                switch result{
-                case .success(()):
-                    tableView.reloadData()
-                case .failure(let error):
-                    if error == .networkError{
-                        UIAlertController.showAPIErrorAlert(error: .networkError, self)
-                    }else{
-                        UIAlertController.showAPIErrorAlert(error: .unknown, self)
-                    }
+        GithubAPI.getRepositoryDataOf(searchWord){ [unowned self] (result) in
+            switch result{
+            case .success(()):
+                tableView.reloadData()
+            case .failure(let error):
+                switch error{
+                case .networkError:
+                    return UIAlertController.showAPIErrorAlert(error: .networkError, self)
+                case .invalidURL:
+                    return UIAlertController.showAPIErrorAlert(error: .invalidURL, self)
+                default:
+                    return UIAlertController.showAPIErrorAlert(error: .unknown, self)
                 }
             }
-        }catch APIError.invalidURL{
-            UIAlertController.showAPIErrorAlert(error: .invalidURL, self)
-        }catch{
-            UIAlertController.showAPIErrorAlert(error: .unknown, self)
         }
     }
 }

--- a/iOSEngineerCodeCheck/Model/GithubAPI.swift
+++ b/iOSEngineerCodeCheck/Model/GithubAPI.swift
@@ -13,9 +13,9 @@ import Alamofire
 final class GithubAPI{
     
     ///githubAPIにリクエストを投げてリポジトリのデータを取得する
-    static func getRepositoryDataOf(_ searchWord:String, completion:@escaping(Result<(),APIError>)->Void) throws{
+    static func getRepositoryDataOf(_ searchWord:String, completion:@escaping(Result<(),APIError>)->Void){
         guard let url = URL(string: "https://api.github.com/search/repositories?q=\(searchWord)")
-        else { throw APIError.invalidURL }
+        else { return completion(.failure(.invalidURL)) }
         AF.request(url, method: .get, parameters: nil, encoding: JSONEncoding.default).responseJSON { (response) in
             do{
                 guard let data = response.data


### PR DESCRIPTION
コードをより簡潔にするためthrowせずに.failureに統一、.failure内でswitch文を使ってエラーを網羅するよう変更